### PR TITLE
Remove/Update REST API spec urls for x-pack

### DIFF
--- a/Elastic.Console/Elastic.Console.psm1
+++ b/Elastic.Console/Elastic.Console.psm1
@@ -168,13 +168,9 @@ function Set-ElasticsearchVersion {
             $contentsApi = "https://api.github.com/repos/elastic/elasticsearch/contents"
             $specUrls = @("$contentsApi/rest-api-spec/src/main/resources/rest-api-spec/api?ref=v$Version")
 
-            # Get the REST API specs for Elastic Stack Feature/X-Pack endpoints too, when available
-            if ($Version -ge "6.3.0") {
-                $specUrls += "$contentsApi/x-pack/plugin/src/test/resources/rest-api-spec/api?ref=v$Version"
-            }
-
             $downloadurls = $specUrls | Foreach-Object  {
-                Invoke-RestMethod $_ | Where-Object { $_.name.EndsWith(".json") } | Foreach-Object { $_.download_url }
+                
+                Method $_ | Where-Object { $_.name.EndsWith(".json") } | Foreach-Object { $_.download_url }
             }
 
             # TODO: optimize by downloading in parallel

--- a/Elastic.Console/Elastic.Console.psm1
+++ b/Elastic.Console/Elastic.Console.psm1
@@ -169,8 +169,7 @@ function Set-ElasticsearchVersion {
             $specUrls = @("$contentsApi/rest-api-spec/src/main/resources/rest-api-spec/api?ref=v$Version")
 
             $downloadurls = $specUrls | Foreach-Object  {
-                
-                Method $_ | Where-Object { $_.name.EndsWith(".json") } | Foreach-Object { $_.download_url }
+                Invoke-RestMethod $_ | Where-Object { $_.name.EndsWith(".json") } | Foreach-Object { $_.download_url }
             }
 
             # TODO: optimize by downloading in parallel


### PR DESCRIPTION
The url for x-pack specs is no longer valid and should be updated or modified otherwise the below message appears:

```
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest/reference/repos#get-repository-content"
}
```